### PR TITLE
Initial compile against RimWorld 1.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+# Local file paths defninitions
+Directory.Build.props
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,7 @@
 	<name>Ctrl F - Dev Build</name>
 	<author>Uuugggg</author>
 	<supportedVersions>
-		<li>1.5</li>
+		<li>1.6</li>
 	</supportedVersions>
 	<packageId>DEBUuugggg.CtrlF</packageId>
 	<description>Press Ctrl-F to find anything on the map, with very thorough options to filter the list. 

--- a/About/About.xml
+++ b/About/About.xml
@@ -10,4 +10,15 @@
 (This is the dev version of Ctrl F. The release version of About.xml is available for editing at About/About-Release.xml. Edits made on this file or on the temporary About/About.xml won't show up on the release version. Use VisualStudio to build a "Release" version of this mod when ready to upload your mod!)</description>
 	<url>https://steamcommunity.com/id/Uuugggg/myworkshopfiles/?appid=294100</url>
 	<modIconPath IgnoreIfNoMatchingField="True">TDCtrlFIcon</modIconPath>
+	<modDependencies>
+		<li>
+			<packageId>DEBUuugggg.TDFindLib</packageId>
+			<displayName>TD Find Library</displayName>
+			<steamWorkshopUrl>steam://url/CommunityFilePage/2895299310</steamWorkshopUrl>
+			<downloadUrl>https://github.com/alextd/RimWorld-TDFindLib/releases/latest</downloadUrl>
+		</li>
+	</modDependencies>
+	<loadAfter>
+		<li>DEBUuugggg.TDFindLib</li>
+	</loadAfter>
 </ModMetaData>

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,29 +1,19 @@
-Alex's Legacy License (Based on MIT)
-
-Copyright (c) 2025 Alex Tearse-Doyle “TD” (steam id: Uuugggg)
+Copyright (c) [2025] [Alex Tearse-Doyle]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. The name “Alex Tearse-Doyle” shall be preserved as the original author of
-   the Software in any derivative works or redistributions.
-
-3. This license does not transfer ownership of the Software. All rights,
-   moral and legal, remain with the original author, Alex Tearse-Doyle, or his legal estate.
-
-4. The Software is provided “as is”, without warranty of any kind, express or
-   implied, including but not limited to the warranties of merchantability,
-   fitness for a particular purpose and noninfringement. In no event shall
-   the author or copyright holders be liable for any claim, damages or other
-   liability, whether in an action of contract, tort or otherwise, arising
-   from, out of or in connection with the Software or the use or other
-   dealings in the Software.
-
-IN MEMORY OF ALEX — Thank you for your creativity and contributions.
-
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,24 +1,6 @@
-# RimWorld-CtrlF
-Press Ctrl-F to search for things on the map.
-
-https://steamcommunity.com/sharedfiles/filedetails/?id=2895300634
-
-
-# Notice
-
-Alex Tearse-Doyle “TD” (steam id: Uuugggg) has passed away unexpectedly. He was a young single 38 year old whose life was games, gaming, creating games. Professionally he was a software engineer. He was just starting at being self employed as a game creator..see TDsGames.com — he recently launched a game "Word Limit" and suddenly encounter such tragedy.
-
-He was a highly respected member of the RimWorld modding community, and he has made significant contributions.
-
-His family is willing to see that his work is being continued and memorialized by the community.
-
-Please always take a moment to pray for Alex and his family when you use his work.
-
-# License
-
 Alex's Legacy License (Based on MIT)
 
-Copyright (c) [year] Alex Tearse-Doyle “TD” (steam id: Uuugggg)
+Copyright (c) 2025 Alex Tearse-Doyle “TD” (steam id: Uuugggg)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the “Software”), to use,

--- a/README.md
+++ b/README.md
@@ -13,35 +13,3 @@ He was a highly respected member of the RimWorld modding community, and he has m
 His family is willing to see that his work is being continued and memorialized by the community.
 
 Please always take a moment to pray for Alex and his family when you use his work.
-
-# License
-
-Alex's Legacy License (Based on MIT)
-
-Copyright (c) [year] Alex Tearse-Doyle “TD” (steam id: Uuugggg)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the “Software”), to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-1. The above copyright notice and this permission notice shall be included
-   in all copies or substantial portions of the Software.
-
-2. The name “Alex Tearse-Doyle” shall be preserved as the original author of
-   the Software in any derivative works or redistributions.
-
-3. This license does not transfer ownership of the Software. All rights,
-   moral and legal, remain with the original author, Alex Tearse-Doyle, or his legal estate.
-
-4. The Software is provided “as is”, without warranty of any kind, express or
-   implied, including but not limited to the warranties of merchantability,
-   fitness for a particular purpose and noninfringement. In no event shall
-   the author or copyright holders be liable for any claim, damages or other
-   liability, whether in an action of contract, tort or otherwise, arising
-   from, out of or in connection with the Software or the use or other
-   dealings in the Software.
-
-IN MEMORY OF ALEX — Thank you for your creativity and contributions.
-

--- a/Source/Ctrl_F.csproj
+++ b/Source/Ctrl_F.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,6 +10,9 @@
     <RootNamespace>Ctrl_F</RootNamespace>
     <AssemblyName>Ctrl_F</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFramework>net472</TargetFramework>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <FileAlignment>512</FileAlignment>
     <AllowedReferenceRelatedFileExtensions>None</AllowedReferenceRelatedFileExtensions>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
- Update .gitignore and uses a local Directory.Build.props file to replace
the dll paths configured in the .csproj file
- Update Ctrl_F.csproj file to be in sdk-style for Linux vscode.
- Update the tag to 1.6